### PR TITLE
Sync to /var/tmp instead of /tmp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM google/cloud-sdk:latest
+RUN apt update && apt install -y time && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 
 COPY ./app .

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The input parameters may also be passed as environment variables as shown in the
 | GCLOUD_PUBSUB_TOPIC_ID                    | The ID of the Pub/Sub topic that receives notifications of changes to your GCS bucket | Yes | None |
 | GCLOUD_BUCKET_NAME                                 | The name of the GCS Bucket to sync data from | Yes | None |
 | GCLOUD_BUCKET_PATH                                 | The path to a specific folder in your GCS Bucket that you'd like to sync data from (Optional) | No | / |
-| GCLOUD_DESTINATION_FOLDER                          | The absolute local path where the GCS bucket's contents will be stored (Optional) | No | /tmp/buckets/  |
+| GCLOUD_DESTINATION_FOLDER                          | The absolute local path where the GCS bucket's contents will be stored (Optional) | No | /var/tmp/buckets/  |
 
 A `sample.env` file is provided in the root folder to be used as a template for the environment variables.
 

--- a/app/main.py
+++ b/app/main.py
@@ -54,7 +54,7 @@ if __name__ == '__main__':
     if args.destination_folder:
         destination_folder = args.destination_folder.rstrip('/')
     else:
-        destination_folder = f"/tmp/buckets/{args.source_bucket}"
+        destination_folder = f"/var/tmp/buckets/{args.source_bucket}"
     
     if not os.path.exists(destination_folder):
         pathlib.Path(
@@ -63,7 +63,7 @@ if __name__ == '__main__':
     logger.info(f"Saving GCS bucket {bucket_path} to {destination_folder}")
 
     rsync_output = exec_shell_command(
-        ['gsutil', '-m', 'rsync', '-d', '-r', bucket_path, destination_folder]
+        ['time', 'gsutil', '-m', 'rsync', '-d', '-r', bucket_path, destination_folder]
     )
     
     # TO-DO: Write to a file after successfull file sync


### PR DESCRIPTION

To prevent data from being stored in RAM and causing performance issues during large syncs, update `gcs-node-sync` to synchronize files to `/var/tmp/buckets` instead of the `/tmp` directory, which resides in RAM.