### PR TITLE
fix: Add verbose arg to run command for log visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The input parameters may also be passed as environment variables as shown in the
 | GCLOUD_BUCKET_NAME                                 | The name of the GCS Bucket to sync data from | Yes | None |
 | GCLOUD_BUCKET_PATH                                 | The path to a specific folder in your GCS Bucket that you'd like to sync data from (Optional) | No | / |
 | GCLOUD_DESTINATION_FOLDER                          | The absolute local path where the GCS bucket's contents will be stored (Optional) | No | /var/tmp/buckets/  |
+| VERBOSE                                            | To view full logs                             |        No |            None
 
 A `sample.env` file is provided in the root folder to be used as a template for the environment variables.
 

--- a/app/main.py
+++ b/app/main.py
@@ -31,6 +31,12 @@ if __name__ == '__main__':
         "--destination_folder", required=False, help="The absolute local path where the GCS bucket's contents will be stored",
         default=os.getenv("GCLOUD_DESTINATION_FOLDER")
     )
+    parser.add_argument(
+        "--verbose",
+        default=os.getenv("VERBOSE", "false").lower() == "true",
+        action="store_true",
+        help="Enable verbose logging output"
+    )
 
     logger = logging.getLogger(__name__)
 
@@ -68,4 +74,4 @@ if __name__ == '__main__':
 
     # TO-DO: Write to a file after successfull file sync
     poll_notifications(args.project, args.pubsub_topic, args.source_bucket,
-                       source_bucket_path, destination_folder, logger)
+                       source_bucket_path, destination_folder, logger, args.verbose)

--- a/app/pubsub.py
+++ b/app/pubsub.py
@@ -9,7 +9,7 @@ from google.cloud import storage
 from google.api_core.exceptions import AlreadyExists
 
 
-def update_files(message, bucket, source_bucket_path, destination_folder, logger):
+def update_files(message, bucket, source_bucket_path, destination_folder, logger, verbose):
     attributes = message.attributes
 
     event_type = attributes["eventType"]
@@ -27,7 +27,8 @@ def update_files(message, bucket, source_bucket_path, destination_folder, logger
         else:
             update_file = False
 
-    logger.info(f"Update = {update_file}. {event_type} -> File path: {file_path}.")
+    if verbose:
+        logger.info(f"Update = {update_file}. {event_type} -> File path: {file_path}.")
     if update_file:
         try:
             file_dir = ("/").join(file_path.split("/")[:-1])
@@ -49,7 +50,7 @@ def update_files(message, bucket, source_bucket_path, destination_folder, logger
             logger.error(f"Error occured: {err}")
 
 
-def poll_notifications(project_id, topic_id, source_bucket, source_bucket_path, destination_folder, logger):
+def poll_notifications(project_id, topic_id, source_bucket, source_bucket_path, destination_folder, logger, verbose):
     """Polls a Cloud Pub/Sub subscription for new GCS events to update local files."""
     host_name = os.uname()[1]
     subscription_id = f"{topic_id}-{host_name}"
@@ -67,7 +68,7 @@ def poll_notifications(project_id, topic_id, source_bucket, source_bucket_path, 
 
     def callback(message):
         update_files(message, bucket, source_bucket_path,
-                     destination_folder, logger)
+                     destination_folder, logger, verbose)
         message.ack()
     try:
         expiration_policy = pubsub_v1.types.ExpirationPolicy(

--- a/sample.env
+++ b/sample.env
@@ -3,3 +3,4 @@ GCLOUD_PUBSUB_TOPIC_ID=""
 GCLOUD_BUCKET_NAME=""
 GCLOUD_BUCKET_PATH=""
 GCLOUD_DESTINATION_FOLDER=""
+VERBOSE="true" # to see full update_files() log. "false" if you don't want to, or remove env var.


### PR DESCRIPTION
How it works, and how to react to the test in the PR:
```
# without verbose
python main.py --project zelus-cricket-dev --pubsub_topic model-versions --source_bucket zelus-cricket-dev-backups --source_bucket_path playing-around/ --destination_folder whatsup/ 
# on another terminal
> while true                                                                    
do gcloud pubsub topics publish model-versions --message="Hello from gcloud" --project=zelus-cricket-dev
done
messageIds:
- '14436825021654805'
messageIds:
- '14437525759331683'
messageIds:
- '14437081482445168'
messageIds:
- '14437086871905249'
messageIds:
- '14437813327654874'
messageIds:
- '14182663405205253'
# -----
# output:
2025-04-10 00:39:09,760 INFO     Subscription projects/zelus-cricket-dev/subscriptions/model-versions-Mac already exists in topic projects/zelus-cricket-dev/topics/model-versions
2025-04-10 00:39:09,761 INFO     Listening for messages on projects/zelus-cricket-dev/subscriptions/model-versions-Mac

# Summary: messages are being published to the topic, but the logs are limited and just listening until something fails.

# -----------
# with verbose
python main.py --project zelus-cricket-dev --pubsub_topic model-versions --source_bucket zelus-cricket-dev-backups --source_bucket_path playing-around/ --destination_folder whatsup/ --verbose
# on another terminal
> while true                                                                    
do gcloud pubsub topics publish model-versions --message="Hello from gcloud" --project=zelus-cricket-dev
done
messageIds:
- '14438414783904887'
messageIds:
- '14440151494121493'
messageIds:
- '14436594848925166'
messageIds:
- '14437450546331510'
messageIds:
- '14437804913211399'
messageIds:
- '14437125061871911'
messageIds:
- '14437133613942410'

# ------
# output:
2025-04-10 00:34:02,487 INFO     Subscription projects/zelus-cricket-dev/subscriptions/model-versions-Mac already exists in topic projects/zelus-cricket-dev/topics/model-versions
2025-04-10 00:34:02,489 INFO     Listening for messages on projects/zelus-cricket-dev/subscriptions/model-versions-Mac


2025-04-10 00:35:49,972 INFO     Update = False.  -> File path: whatsup/.
2025-04-10 00:35:50,555 INFO     Update = False.  -> File path: whatsup/.
2025-04-10 00:35:51,483 INFO     Update = False.  -> File path: whatsup/.
2025-04-10 00:35:52,328 INFO     Update = False.  -> File path: whatsup/.
2025-04-10 00:35:53,903 INFO     Update = False.  -> File path: whatsup/.
2025-04-10 00:35:54,184 INFO     Update = False.  -> File path: whatsup/.
2025-04-10 00:35:55,089 INFO     Update = False.  -> File path: whatsup/.
2025-04-10 00:35:55,956 INFO     Update = False.  -> File path: whatsup/.
```

For a container image env var: `VERBOSE="true"` to see full logs, not specified or `false` will not show full logs.
